### PR TITLE
Implement on-chain optimal fee algorithm

### DIFF
--- a/contracts/interfaces/IParetoManager.sol
+++ b/contracts/interfaces/IParetoManager.sol
@@ -36,6 +36,7 @@ interface IParetoManager {
      * @notice Computes the strike price for the next pool by back-deriving strike
      *         from a known delta, implied volatility, and spot price
      * @dev Uses the same decimals as the stable token
+     * @param spot Spot price for risky in terms of stable asset
      * @param delta Black Scholes delta
      * @param sigma Implied volatility
      * @param tau Time to maturity in seconds.
@@ -44,11 +45,12 @@ interface IParetoManager {
      * @return strikePrice Relative price of risky in stable
      */
     function getNextStrikePrice(
+        uint256 spot,
         uint32 delta,
         uint32 sigma,
         uint256 tau,
         uint8 stableDecimals
-    ) external view returns (uint128);
+    ) external pure returns (uint128);
 
     /**
      * @notice Computes the volatility for the next pool
@@ -60,11 +62,20 @@ interface IParetoManager {
 
     /**
      * @notice Computes the gamma (or 1 - fee) for the next pool
-     * @dev Currently hardcoded to 95% (or 5% fees).
-     *      Choosing gamma effects the quality of replication
+     * @dev Uses a pre-trained linear regression model to map (S/K, sigma) 
+     *      to prediction of optimal fee. Returns gamma as 1 - that fee
+     * @param spot Spot price for risky in terms of stable asset
+     * @param strike Strike price for risky in terms of stable asset
+     * @param sigma Implied volatility
+     * @param stableDecimals Decimals for the stable asset
      * @return gamma Gamma for the next pool
      */
-    function getNextGamma() external pure returns (uint32);
+    function getNextGamma(
+      uint256 spot,
+      uint128 strike,
+      uint32 sigma,
+      uint8 stableDecimals
+    ) external pure returns (uint32 gamma);
 
     /**
      * @notice Computes the Black Scholes delta value

--- a/contracts/libraries/LinearRegression.sol
+++ b/contracts/libraries/LinearRegression.sol
@@ -16,6 +16,7 @@ library LinearRegression {
 
     /**
      * @notice Compute `y_hat = x^Tw + b`
+     * @dev Currently hardcoded to have two inputs
      * @param inputs One dimensional array of input features
      * @param weights One dimensional array of weight features
      * @param bias Scalar intercept term
@@ -28,19 +29,15 @@ library LinearRegression {
      * @return predSign Boolean where true is positive and false is negative
      */
     function predict(
-        uint256[] memory inputs,
-        uint256[] memory weights,
+        uint256[2] memory inputs,
+        uint256[2] memory weights,
         uint256 bias,
-        bool[] memory inputSigns,
-        bool[] memory weightSigns,
+        bool[2] memory inputSigns,
+        bool[2] memory weightSigns,
         bool biasSign,
         uint256 inputScaleFactor,
         uint256 weightScaleFactor
     ) internal pure returns (uint256 pred, bool predSign) {
-        require(inputs.length == weights.length, "!length");
-        require(inputs.length == inputSigns.length, "!length");
-        require(weights.length == weightSigns.length, "!length");
-
         int128 inputX64;
         int128 weightX64;
         int128 predX64;

--- a/contracts/libraries/LinearRegression.sol
+++ b/contracts/libraries/LinearRegression.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.8.6;
+
+import {ABDKMath64x64} from "./ABDKMath64x64.sol";
+import {Units} from "@primitivefi/rmm-core/contracts/libraries/Units.sol";
+
+/**
+ * @notice Linear regression model
+ * @dev Does not fit a linear model. Only used for inference.
+ */
+library LinearRegression {
+    using ABDKMath64x64 for int128;
+    using ABDKMath64x64 for uint256;
+    using Units for int128;
+    using Units for uint256;
+
+    /**
+     * @notice Compute `y_hat = x^Tw + b`
+     * @param inputs One dimensional array of input features
+     * @param weights One dimensional array of weight features
+     * @param bias Scalar intercept term
+     * @param inputSigns Boolean array where true is positive and false is negative
+     * @param weightSigns Boolean array where true is positive and false is negative
+     * @param biasSign Boolean where true is positive and false is negative
+     * @param inputScaleFactor Unsigned 256-bit integer scaling factor for inputs e.g. 10^(18 - decimals())
+     * @param weightScaleFactor Unsigned 256-bit integer scaling factor for weights + bias e.g. 10^(18 - decimals())
+     * @return pred Predicted value, in same decimals as inputs
+     * @return predSign Boolean where true is positive and false is negative
+     */
+    function predict(
+        uint256[] memory inputs,
+        uint256[] memory weights,
+        uint256 bias,
+        bool[] memory inputSigns,
+        bool[] memory weightSigns,
+        bool biasSign,
+        uint256 inputScaleFactor,
+        uint256 weightScaleFactor
+    ) internal pure returns (
+        uint256 pred,
+        bool predSign
+    ) {
+        require(inputs.length == weights.length, "!length");
+
+        // Restrict to lower than 10 dimensional
+        require(inputs.length < 10, "too big");
+
+        int128 inputX64;
+        int128 weightX64;
+        int128 predX64;
+
+        for (uint256 i = 0; i < inputs.length; i++) {
+            inputX64 = inputs[i].scaleToX64(inputScaleFactor);
+            weightX64 = weights[i].scaleToX64(weightScaleFactor);
+            if (!inputSigns[i]) {
+                inputX64 = inputX64.neg();
+            }
+            if (!weightSigns[i]) {
+                weightX64 = weightX64.neg();
+            }
+            predX64 = predX64.add(inputX64.mul(weightX64));
+        }
+
+        // Add a bias term
+        int128 biasX64 = bias.scaleToX64(weightScaleFactor);
+        if (!biasSign) {
+            biasX64 = biasX64.neg();
+        }
+        predX64 = predX64.add(biasX64);
+        predSign = !(predX64 < 0);  // false if negative
+        if (!predSign) {
+            predX64 = predX64.neg();
+        }
+        pred = predX64.scaleFromX64(inputScaleFactor);
+        return (pred, predSign);
+    }
+}

--- a/contracts/libraries/LinearRegression.sol
+++ b/contracts/libraries/LinearRegression.sol
@@ -36,14 +36,10 @@ library LinearRegression {
         bool biasSign,
         uint256 inputScaleFactor,
         uint256 weightScaleFactor
-    ) internal pure returns (
-        uint256 pred,
-        bool predSign
-    ) {
+    ) internal pure returns (uint256 pred, bool predSign) {
         require(inputs.length == weights.length, "!length");
-
-        // Restrict to lower than 10 dimensional
-        require(inputs.length < 10, "too big");
+        require(inputs.length == inputSigns.length, "!length");
+        require(weights.length == weightSigns.length, "!length");
 
         int128 inputX64;
         int128 weightX64;
@@ -67,7 +63,7 @@ library LinearRegression {
             biasX64 = biasX64.neg();
         }
         predX64 = predX64.add(biasX64);
-        predSign = !(predX64 < 0);  // false if negative
+        predSign = !(predX64 < 0); // false if negative
         if (!predSign) {
             predX64 = predX64.neg();
         }

--- a/contracts/test/TestLinearRegression.sol
+++ b/contracts/test/TestLinearRegression.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.6;
+
+import {LinearRegression} from "../libraries/LinearRegression.sol";
+
+/**
+ * @notice Test contract to wrap around LinearRegression.sol library
+ */
+contract TestLinearRegression {
+    function predict(
+        uint256[] memory inputs,
+        uint256[] memory weights,
+        uint256 bias,
+        bool[] memory inputSigns,
+        bool[] memory weightSigns,
+        bool biasSign,
+        uint256 inputScaleFactor,
+        uint256 weightScaleFactor
+    ) external pure returns (uint256 pred, bool predSign) {
+        return
+            LinearRegression.predict(
+                inputs,
+                weights,
+                bias,
+                inputSigns,
+                weightSigns,
+                biasSign,
+                inputScaleFactor,
+                weightScaleFactor
+            );
+    }
+}

--- a/contracts/test/TestLinearRegression.sol
+++ b/contracts/test/TestLinearRegression.sol
@@ -8,11 +8,11 @@ import {LinearRegression} from "../libraries/LinearRegression.sol";
  */
 contract TestLinearRegression {
     function predict(
-        uint256[] memory inputs,
-        uint256[] memory weights,
+        uint256[2] memory inputs,
+        uint256[2] memory weights,
         uint256 bias,
-        bool[] memory inputSigns,
-        bool[] memory weightSigns,
+        bool[2] memory inputSigns,
+        bool[2] memory weightSigns,
         bool biasSign,
         uint256 inputScaleFactor,
         uint256 weightScaleFactor

--- a/test/libraries/linreg.test.ts
+++ b/test/libraries/linreg.test.ts
@@ -1,0 +1,386 @@
+import hre, { ethers } from "hardhat";
+import { Contract } from "ethers";
+import expect from "../shared/expect";
+import { fromBn, toBn } from "evm-bn";
+import { fromBnToFloat } from "../../scripts/utils/testUtils";
+
+let linearRegression: Contract;
+
+describe("TestLinearRegression contract", () => {
+  beforeEach(async function () {
+    const [deployer] = await hre.ethers.getSigners();
+    const TestLinearRegression = await ethers.getContractFactory(
+      "TestLinearRegression",
+      deployer
+    );
+    linearRegression = await TestLinearRegression.deploy();
+  });
+  describe("Check the prediction function", function () {
+    it("Check error if lengths do not match", async function () {
+      let inputs = [toBn("1", 18).toString(), toBn("2", 18).toString()];
+      let weights = [toBn("1", 18).toString()];
+      let bias = toBn("1", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [true];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      try {
+        await linearRegression.predict(
+          inputs,
+          weights,
+          bias,
+          inputSigns,
+          weightSigns,
+          biasSign,
+          inputScaleFactor,
+          weightScaleFactor
+        );
+      } catch (err) {
+        expect(err.message).to.include("!length");
+      }
+    });
+    it("Check one-dimensional with positive inputs and positive weights: test 1/3", async function () {
+      let inputs = [toBn("1", 18).toString()];
+      let weights = [toBn("1", 18).toString()];
+      let bias = toBn("1", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [true];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBn(outputs.pred, 18)).to.equal("2");
+    });
+    it("Check one-dimensional with positive inputs and positive weights: test 2/3", async function () {
+      let inputs = [toBn("3.141", 18).toString()];
+      let weights = [toBn("0.783", 18).toString()];
+      let bias = toBn("1.182", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [true];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 3.141 * 0.783 + 1.182;
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(answer, 1e-3);
+    });
+    it("Check one-dimensional with positive inputs and positive weights: test 3/3", async function () {
+      let inputs = [toBn("0.998", 18).toString()];
+      let weights = [toBn("8.214", 18).toString()];
+      let bias = toBn("4.444", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [true];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 0.998 * 8.214 + 4.444;
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(answer, 1e-3);
+    });
+    it("Check one-dimensional with positive inputs and negative weights: test 1/3", async function () {
+      let inputs = [toBn("1", 18).toString()];
+      let weights = [toBn("1", 18).toString()];
+      let bias = toBn("1", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [false];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBn(outputs.pred, 18)).to.equal("0");
+    });
+    it("Check one-dimensional with positive inputs and negative weights: test 2/3", async function () {
+      let inputs = [toBn("3.141", 18).toString()];
+      let weights = [toBn("0.783", 18).toString()];
+      let bias = toBn("1.182", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [false];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 3.141 * -0.783 + 1.182;
+      expect(outputs.predSign).to.equal(answer >= 0);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(
+        Math.abs(answer),
+        1e-3
+      );
+    });
+    it("Check one-dimensional with positive inputs and negative weights: test 3/3", async function () {
+      let inputs = [toBn("0.998", 18).toString()];
+      let weights = [toBn("8.214", 18).toString()];
+      let bias = toBn("4.444", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [false];
+      let biasSign = false;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 0.998 * -8.214 - 4.444;
+      expect(outputs.predSign).to.equal(answer >= 0);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(
+        Math.abs(answer),
+        1e-3
+      );
+    });
+    it("Check one-dimensional with negative inputs and negative weights: test 1/3", async function () {
+      let inputs = [toBn("1", 18).toString()];
+      let weights = [toBn("1", 18).toString()];
+      let bias = toBn("1", 18).toString();
+      let inputSigns = [false];
+      let weightSigns = [false];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBn(outputs.pred, 18)).to.equal("2");
+    });
+    it("Check one-dimensional with negative inputs and negative weights: test 2/3", async function () {
+      let inputs = [toBn("3.141", 18).toString()];
+      let weights = [toBn("0.783", 18).toString()];
+      let bias = toBn("1.182", 18).toString();
+      let inputSigns = [false];
+      let weightSigns = [false];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = -3.141 * -0.783 + 1.182;
+      expect(outputs.predSign).to.equal(answer >= 0);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(
+        Math.abs(answer),
+        1e-3
+      );
+    });
+    it("Check one-dimensional with negative inputs and negative weights: test 3/3", async function () {
+      let inputs = [toBn("0.998", 18).toString()];
+      let weights = [toBn("8.214", 18).toString()];
+      let bias = toBn("4.444", 18).toString();
+      let inputSigns = [false];
+      let weightSigns = [false];
+      let biasSign = false;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = -0.998 * -8.214 - 4.444;
+      expect(outputs.predSign).to.equal(answer >= 0);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(
+        Math.abs(answer),
+        1e-3
+      );
+    });
+    it("Check two-dimensional computation: test 1/3", async function () {
+      let inputs = [toBn("1", 18).toString(), toBn("1", 18).toString()];
+      let weights = [toBn("1", 18).toString(), toBn("1", 18).toString()];
+      let bias = toBn("1", 18).toString();
+      let inputSigns = [true, true];
+      let weightSigns = [true, true];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBn(outputs.pred, 18)).to.equal("3");
+    });
+    it("Check two-dimensional computation: test 2/3", async function () {
+      let inputs = [toBn("3.141", 18).toString(), toBn("0.998", 18).toString()];
+      let weights = [
+        toBn("0.783", 18).toString(),
+        toBn("8.214", 18).toString(),
+      ];
+      let bias = toBn("4.444", 18).toString();
+      let inputSigns = [true, true];
+      let weightSigns = [true, true];
+      let biasSign = true;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 3.141 * 0.783 + 0.998 * 8.214 + 4.444;
+      expect(outputs.predSign).to.equal(answer >= 0);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(
+        Math.abs(answer),
+        1e-3
+      );
+    });
+    it("Check two-dimensional computation: test 2/3", async function () {
+      let inputs = [toBn("3.141", 18).toString(), toBn("0.998", 18).toString()];
+      let weights = [
+        toBn("0.783", 18).toString(),
+        toBn("8.214", 18).toString(),
+      ];
+      let bias = toBn("4.444", 18).toString();
+      let inputSigns = [true, false];
+      let weightSigns = [false, true];
+      let biasSign = false;
+      let inputScaleFactor = 1;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 3.141 * -0.783 - 0.998 * 8.214 - 4.444;
+      expect(outputs.predSign).to.equal(answer >= 0);
+      expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(
+        Math.abs(answer),
+        1e-3
+      );
+    });
+    it("Check prediction with smaller scale factor", async function () {
+      let inputs = [toBn("3.141", 15).toString()];
+      let weights = [toBn("0.783", 15).toString()];
+      let bias = toBn("1.182", 15).toString();
+      let inputSigns = [true];
+      let weightSigns = [true];
+      let biasSign = true;
+      let inputScaleFactor = 10 ** 3;
+      let weightScaleFactor = 10 ** 3;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 3.141 * 0.783 + 1.182;
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBnToFloat(outputs.pred, 15)).to.be.closeTo(answer, 1e-3);
+    });
+    it("Check prediction with different scale factors", async function () {
+      let inputs = [toBn("3.141", 15).toString()];
+      let weights = [toBn("0.783", 18).toString()];
+      let bias = toBn("1.182", 18).toString();
+      let inputSigns = [true];
+      let weightSigns = [true];
+      let biasSign = true;
+      let inputScaleFactor = 10 ** 3;
+      let weightScaleFactor = 1;
+      let outputs = await linearRegression.predict(
+        inputs,
+        weights,
+        bias,
+        inputSigns,
+        weightSigns,
+        biasSign,
+        inputScaleFactor,
+        weightScaleFactor
+      );
+      let answer = 3.141 * 0.783 + 1.182;
+      expect(outputs.predSign).to.equal(true);
+      expect(fromBnToFloat(outputs.pred, 15)).to.be.closeTo(answer, 1e-3);
+    });
+  });
+});

--- a/test/libraries/linreg.test.ts
+++ b/test/libraries/linreg.test.ts
@@ -16,36 +16,12 @@ describe("TestLinearRegression contract", () => {
     linearRegression = await TestLinearRegression.deploy();
   });
   describe("Check the prediction function", function () {
-    it("Check error if lengths do not match", async function () {
-      let inputs = [toBn("1", 18).toString(), toBn("2", 18).toString()];
-      let weights = [toBn("1", 18).toString()];
-      let bias = toBn("1", 18).toString();
-      let inputSigns = [true];
-      let weightSigns = [true];
-      let biasSign = true;
-      let inputScaleFactor = 1;
-      let weightScaleFactor = 1;
-      try {
-        await linearRegression.predict(
-          inputs,
-          weights,
-          bias,
-          inputSigns,
-          weightSigns,
-          biasSign,
-          inputScaleFactor,
-          weightScaleFactor
-        );
-      } catch (err) {
-        expect(err.message).to.include("!length");
-      }
-    });
     it("Check one-dimensional with positive inputs and positive weights: test 1/3", async function () {
-      let inputs = [toBn("1", 18).toString()];
-      let weights = [toBn("1", 18).toString()];
+      let inputs = [toBn("1", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("1", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("1", 18).toString();
-      let inputSigns = [true];
-      let weightSigns = [true];
+      let inputSigns = [true, true];
+      let weightSigns = [true, true];
       let biasSign = true;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -63,11 +39,11 @@ describe("TestLinearRegression contract", () => {
       expect(fromBn(outputs.pred, 18)).to.equal("2");
     });
     it("Check one-dimensional with positive inputs and positive weights: test 2/3", async function () {
-      let inputs = [toBn("3.141", 18).toString()];
-      let weights = [toBn("0.783", 18).toString()];
+      let inputs = [toBn("3.141", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("0.783", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("1.182", 18).toString();
-      let inputSigns = [true];
-      let weightSigns = [true];
+      let inputSigns = [true, true];
+      let weightSigns = [true, true];
       let biasSign = true;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -86,11 +62,11 @@ describe("TestLinearRegression contract", () => {
       expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(answer, 1e-3);
     });
     it("Check one-dimensional with positive inputs and positive weights: test 3/3", async function () {
-      let inputs = [toBn("0.998", 18).toString()];
-      let weights = [toBn("8.214", 18).toString()];
+      let inputs = [toBn("0.998", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("8.214", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("4.444", 18).toString();
-      let inputSigns = [true];
-      let weightSigns = [true];
+      let inputSigns = [true, true];
+      let weightSigns = [true, true];
       let biasSign = true;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -109,11 +85,11 @@ describe("TestLinearRegression contract", () => {
       expect(fromBnToFloat(outputs.pred, 18)).to.be.closeTo(answer, 1e-3);
     });
     it("Check one-dimensional with positive inputs and negative weights: test 1/3", async function () {
-      let inputs = [toBn("1", 18).toString()];
-      let weights = [toBn("1", 18).toString()];
+      let inputs = [toBn("1", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("1", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("1", 18).toString();
-      let inputSigns = [true];
-      let weightSigns = [false];
+      let inputSigns = [true, true];
+      let weightSigns = [false, true];
       let biasSign = true;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -131,11 +107,11 @@ describe("TestLinearRegression contract", () => {
       expect(fromBn(outputs.pred, 18)).to.equal("0");
     });
     it("Check one-dimensional with positive inputs and negative weights: test 2/3", async function () {
-      let inputs = [toBn("3.141", 18).toString()];
-      let weights = [toBn("0.783", 18).toString()];
+      let inputs = [toBn("3.141", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("0.783", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("1.182", 18).toString();
-      let inputSigns = [true];
-      let weightSigns = [false];
+      let inputSigns = [true, true];
+      let weightSigns = [false, true];
       let biasSign = true;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -157,11 +133,11 @@ describe("TestLinearRegression contract", () => {
       );
     });
     it("Check one-dimensional with positive inputs and negative weights: test 3/3", async function () {
-      let inputs = [toBn("0.998", 18).toString()];
-      let weights = [toBn("8.214", 18).toString()];
+      let inputs = [toBn("0.998", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("8.214", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("4.444", 18).toString();
-      let inputSigns = [true];
-      let weightSigns = [false];
+      let inputSigns = [true, true];
+      let weightSigns = [false, true];
       let biasSign = false;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -183,11 +159,11 @@ describe("TestLinearRegression contract", () => {
       );
     });
     it("Check one-dimensional with negative inputs and negative weights: test 1/3", async function () {
-      let inputs = [toBn("1", 18).toString()];
-      let weights = [toBn("1", 18).toString()];
+      let inputs = [toBn("1", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("1", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("1", 18).toString();
-      let inputSigns = [false];
-      let weightSigns = [false];
+      let inputSigns = [false, true];
+      let weightSigns = [false, true];
       let biasSign = true;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -205,11 +181,11 @@ describe("TestLinearRegression contract", () => {
       expect(fromBn(outputs.pred, 18)).to.equal("2");
     });
     it("Check one-dimensional with negative inputs and negative weights: test 2/3", async function () {
-      let inputs = [toBn("3.141", 18).toString()];
-      let weights = [toBn("0.783", 18).toString()];
+      let inputs = [toBn("3.141", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("0.783", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("1.182", 18).toString();
-      let inputSigns = [false];
-      let weightSigns = [false];
+      let inputSigns = [false, true];
+      let weightSigns = [false, true];
       let biasSign = true;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;
@@ -231,11 +207,11 @@ describe("TestLinearRegression contract", () => {
       );
     });
     it("Check one-dimensional with negative inputs and negative weights: test 3/3", async function () {
-      let inputs = [toBn("0.998", 18).toString()];
-      let weights = [toBn("8.214", 18).toString()];
+      let inputs = [toBn("0.998", 18).toString(), toBn("0", 18).toString()];
+      let weights = [toBn("8.214", 18).toString(), toBn("0", 18).toString()];
       let bias = toBn("4.444", 18).toString();
-      let inputSigns = [false];
-      let weightSigns = [false];
+      let inputSigns = [false, true];
+      let weightSigns = [false, true];
       let biasSign = false;
       let inputScaleFactor = 1;
       let weightScaleFactor = 1;

--- a/test/manager.test.ts
+++ b/test/manager.test.ts
@@ -175,6 +175,7 @@ describe("ParetoManager contract", function () {
     it("correctly get next strike price - default", async function () {
       let spotPrice = await manager.getRiskyToStablePrice();
       let strikePrice = await manager.getNextStrikePrice(
+        toBn("1", 18),
         2000,
         8000,
         604800,
@@ -192,6 +193,7 @@ describe("ParetoManager contract", function () {
     it("correctly get next strike price - change delta", async function () {
       let spotPrice = await manager.getRiskyToStablePrice();
       let strikePrice = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         8000,
         604800,
@@ -208,12 +210,14 @@ describe("ParetoManager contract", function () {
     });
     it("correctly get next strike price - check delta direction", async function () {
       let strikePrice1 = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         8000,
         604800,
         stableDecimals
       );
       let strikePrice2 = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1500,
         8000,
         604800,
@@ -227,6 +231,7 @@ describe("ParetoManager contract", function () {
     it("correctly get next strike price - check different tau", async function () {
       let spotPrice = await manager.getRiskyToStablePrice();
       let strikePrice = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         8000,
         86400,
@@ -243,12 +248,14 @@ describe("ParetoManager contract", function () {
     });
     it("correctly get next strike price - check tau direction", async function () {
       let strikePrice1 = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         8000,
         86400,
         stableDecimals
       );
       let strikePrice2 = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         8000,
         604800,
@@ -262,6 +269,7 @@ describe("ParetoManager contract", function () {
     it("correctly get next strike price - check different sigma", async function () {
       let spotPrice = await manager.getRiskyToStablePrice();
       let strikePrice = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         1000,
         604800,
@@ -278,12 +286,14 @@ describe("ParetoManager contract", function () {
     });
     it("correctly get next strike price - check sigma direction", async function () {
       let strikePrice1 = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         8000,
         604800,
         stableDecimals
       );
       let strikePrice2 = await manager.getNextStrikePrice(
+        toBn("1", 18),
         1000,
         1000,
         604800,
@@ -304,6 +314,7 @@ describe("ParetoManager contract", function () {
       );
       let spotPrice = await manager.getRiskyToStablePrice();
       let strikePrice = await manager.getNextStrikePrice(
+        toBn("0.31847133758", 18),  // 1 / 3.14
         2000,
         8000,
         604800,


### PR DESCRIPTION
Fit a linear regression model from `(strike/spot, vol)` to `fee` off-chain. Implement on-chain the forward pass once strike and volatility have been chosen.

Training the logreg model on simulation data was done in https://github.com/pareto-xyz/pareto-theta-vault-v1/pull/15. This pull requests implements the on-chain inference code. Added extensive tests for `LinearRegression.sol` along with a mock contract to test the library functions.

`ParetoManager.sol` will use `LinearRegression.sol` to compute fees. 

TODO: add tests.